### PR TITLE
⚡️[Improve/Auction-scheduler-54] 스케줄링 트랜잭션 처리 및 조회 읽기전용으로 최적화

### DIFF
--- a/src/main/java/com/selab/auction/item/service/ItemService.java
+++ b/src/main/java/com/selab/auction/item/service/ItemService.java
@@ -63,7 +63,7 @@ public class ItemService {
         return itemRepository.findById(id).orElseThrow(NotExistItemException::new);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<Item> getItemsEntityByItemStateProgress(){
         return itemRepository.findByState(ItemState.PROGRESS);
     }

--- a/src/main/java/com/selab/auction/scheduler/service/SchedulerService.java
+++ b/src/main/java/com/selab/auction/scheduler/service/SchedulerService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,6 +20,7 @@ public class SchedulerService {
     private final ItemService itemService;
 
     @Scheduled(cron = "0 0/10 * * * *")
+    @Transactional
     public void runAfterTenMinuteRepeatItemPeriodValidation() {
         log.info("10분 주기 아이템 경매 기간 점검 실행 시간  => time : " + LocalTime.now());
 
@@ -30,7 +32,5 @@ public class SchedulerService {
                 ))
                 .peek((item) -> log.info(item.getId() + "번 아이템 경매 기간 만료"))
                 .forEach(itemService::updateItemStateToCompleted);
-
-        // 이후 경매 기간이 지난 아이템의 경우 update진행
     }
 }


### PR DESCRIPTION
### 💡 개요
- 스케줄링 서비스가 로그는 처리하였으나 Item의 상태를 변경하지 못하였음
- resolved #54 

### 📑 작업 사항
- schedulerService 어노테이션 추가. 정상 작동 확인
- scheduler 적용을 위한 경매중인 List<Item> 조회하는 메소드 트랜잭션에 읽기전용으로 변경

### ✒️ 코드 리뷰 요청 사항
- 가독성이 좋게 변경 가능하거나 잘못된 기능 유무

### ✔️ 코드 리뷰 반영 사항

